### PR TITLE
Fastqc forward and reverse for multiqc

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -171,7 +171,7 @@ mkdir multiqc_WDir &&
                     	ln -s '$file.forward' '$file_path' &&
                     	#set file_path = os.path.join($file_dir, 'fastqc_rev_data.txt')
                     	ln -s '$file.reverse' '$file_path' &&
-					#end if
+                    #end if
 				#end for
             #elif str($repeat2.type) == "theoretical_gc"
                 #for $file in $repeat2.fastqc_collection_type.input

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -162,13 +162,17 @@ mkdir multiqc_WDir &&
             #if str($repeat2.type) == "data"
                 #for $k, $file in enumerate($repeat2.fastqc_collection_type.input)
                     #set file_dir = os.path.join($repeat_dir, 'file_' + str($k))
-                    #set file_path = os.path.join($file_dir, 'fastqc_data.txt')
                     mkdir '$file_dir' &&
-                    #if str($repeat2.fastqc_collection_type.is_paired) == 'yes':
-                        #set $file = $file.reverse
-                    #end if
-                    ln -s '$file' '$file_path' &&
-                #end for
+                    #if str($repeat2.fastqc_collection_type.is_paired) == 'no':
+                    	#set file_path = os.path.join($file_dir, 'fastqc_data.txt')
+                    	ln -s '$file' '$file_path' &&
+                    #else:
+                    	#set file_path = os.path.join($file_dir, 'fastqc_fwd_data.txt')
+                    	ln -s '$file.forward' '$file_path' &&
+                    	#set file_path = os.path.join($file_dir, 'fastqc_rev_data.txt')
+                    	ln -s '$file.reverse' '$file_path' &&
+					#end if
+				#end for
             #elif str($repeat2.type) == "theoretical_gc"
                 #for $file in $repeat2.fastqc_collection_type.input
                     @ESCAPE_IDENTIFIER@

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -172,7 +172,7 @@ mkdir multiqc_WDir &&
                     	#set file_path = os.path.join($file_dir, 'fastqc_rev_data.txt')
                     	ln -s '$file.reverse' '$file_path' &&
                     #end if
-				#end for
+                #end for
             #elif str($repeat2.type) == "theoretical_gc"
                 #for $file in $repeat2.fastqc_collection_type.input
                     @ESCAPE_IDENTIFIER@


### PR DESCRIPTION
Missing is still the case for the theoretical GC content, but should be analogous. 

Note that the output html content only contains the fastqc results only once, since the same input files are used. 

For the same reason the wrapper is still not useful for paired fastqc output. The reason is that the reports will allways have the name forward and reverse, resp.. Somehow the fastqc wrapper needs to be adapted to get the sample name (collection identifier) in instead of the read pair info. 

ping @mvdbeek 

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
